### PR TITLE
app_queue.c: Add options to control holdtime announce

### DIFF
--- a/configs/samples/queues.conf.sample
+++ b/configs/samples/queues.conf.sample
@@ -323,7 +323,18 @@ monitor-type = MixMonitor
 ; Either yes, no, or only once.
 ; Hold time will be announced as the estimated time.
 ;
-;announce-holdtime = yes|no|once
+;announce-holdtime = yes|no|once|limit|more
+;
+; If you have specified "limit" or "more" for the announce-position option, then the following
+; value is what is used to determine what announcement to play to waiting callers. If you have
+; set the announce-position option to anything else, then this will have no bearing on queue operation
+;
+;announce-holdtime-limit = 5
+;
+; Only announce the caller's position if it has improved since the last announcement.
+; The default value is no.
+;
+; announce-holdtime-only-down = yes
 ;
 ; Queue position announce?
 ; Valid values are "yes," "no," "limit," or "more." If set to "no," then the caller's position will
@@ -384,6 +395,8 @@ monitor-type = MixMonitor
 ;queue-quantity2 = queue-quantity2
 			;	("The current est. holdtime is")
 ;queue-holdtime = queue-holdtime
+			;	("more then")
+;queue-morethen = queue-morethen
 			;	("minute.")
 ;queue-minute = queue-minute
 			;	("minutes.")


### PR DESCRIPTION
Within hight call volume there is poosible to fail playback of
not i18d sound files. Added sound file for 'morethan' sound and possibility
to stop playback if holdtime over the limit.

UserNote: Added queue.conf configuration option to queue-holdtime option and
sound file configuration option 'sound-morethen'
